### PR TITLE
Init quiz data upload to backend

### DIFF
--- a/backend/src/data/json/phonic_trio_quiz.json
+++ b/backend/src/data/json/phonic_trio_quiz.json
@@ -1,0 +1,286 @@
+{
+  "settings": {
+    "syllable_count": 1,
+    "options_per_question": 4,
+    "questions_per_phoneme": 1
+  },
+  "quiz": [
+    {
+      "id": 1,
+      "target": "/iː/",
+      "samples": [
+        { "text": "see",  "IPA": "/siː/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/01_i_ref_see.mp3" },
+        { "text": "beat", "IPA": "/biːt/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/02_i_ref_beat.mp3" },
+        { "text": "team", "IPA": "/tiːm/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/03_i_ref_team.mp3" }
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Hindi",   "word": "की",  "IPA": "/kiː/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/01_i_hindi_%E0%A4%95%E0%A5%80.mp3" },
+          { "language": "Turkish", "word": "bir", "IPA": "/biɾ/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/01_i_turkish_bir.mp3" },
+          { "language": "Spanish", "word": "sí",  "IPA": "/si/",  "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/01_i_spanish_si%CC%81.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Korean",   "word": "개",  "IPA": "/kɛː/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/01_%C9%9B_korean_%E1%84%80%E1%85%A2.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Great! That’s the long E (/iː/) sound!",
+        "incorrect": "Not quite—that was not /iː/."
+      }
+    },
+    {
+      "id": 2,
+      "target": "/ɪ/",
+      "samples": [
+        { "text": "sit",  "IPA": "/sɪt/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/04_%C9%AA_ref_sit.mp33" },
+        { "text": "bit",  "IPA": "/bɪt/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/05_%C9%AA_ref_bit.mp3" },
+        { "text": "ship", "IPA": "/ʃɪp/","audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/06_%C9%AA_ref_ship.mp3" }
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Turkish", "word": "iç",  "IPA": "/ɪt͡ʃ/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/03_%C9%AA_turkish_ic%CC%A7.mp3" },
+          { "language": "Hindi",  "word": "बिट", "IPA": "/bɪʈ/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/03_%C9%AA_hindi_%E0%A4%AC%E0%A4%BF%E0%A4%9F.mp3" },
+          { "language": "Dutch", "word": "kind",  "IPA": "/kɪnt/",  "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/03_%C9%AA_dutch_kind.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Spanish", "word": "sí",  "IPA": "/si/",  "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/03_i_spanish_si%CC%81.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Exactly—the short I (/ɪ/) sound!",
+        "incorrect": "That wasn’t /ɪ/, try again."
+      }
+    },
+    {
+      "id": 3,
+      "target": "/e/",
+      "samples": [
+        { "text": "say",  "IPA": "/seɪ/","audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/07_e_ref_say.mp3" },
+        { "text": "rain", "IPA": "/reɪn/","audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/08_e_ref_rain.mp3" },
+        { "text": "game", "IPA": "/ɡeɪm/","audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/09_e_ref_game.mp3" }
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "French",   "word": "été", "IPA": "/e.te/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/02_e_french_e%CC%81te%CC%81.mp3" },
+          { "language": "Turkish", "word": "ekmek","IPA": "/ekˈmek/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/02_e_turkish_ekmek.mp3" },
+          { "language": "Spanish", "word": "té",   "IPA": "/te/",   "audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/02_e_spanish_te%CC%81.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Korean",  "word": "네",   "IPA": "/ne/", "audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/02_e_korean_%E1%84%82%E1%85%A6.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Nice—that’s the long A (/e/) sound!",
+        "incorrect": "That wasn’t /e/, give it another shot."
+      }
+    },
+    {
+      "id": 4,
+      "target": "/ɛ/",
+      "samples": [
+        { "text": "bed",  "IPA": "/bɛd/","audio": "https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/10_%C9%9B_ref_bed.mp3"},
+        { "text": "get",  "IPA": "/ɡɛt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/11_%C9%9B_ref_get.mp3"},
+        { "text": "head", "IPA": "/hɛd/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/12_%C9%9B_ref_head.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Dutch",   "word": "bed","IPA":"/bɛt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/04_%C9%9B_dutch_bed.mp3" },
+          { "language": "French", "word": "fête",  "IPA":"/fɛt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/04_%C9%9B_french_fe%CC%82te.mp3" },
+          { "language": "Hindi", "word": "लैब",  "IPA":"/lɛːb/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/04_%C9%9B_hindi_%E0%A4%B2%E0%A5%88%E0%A4%AC.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Turkish",  "word": "el",    "IPA":"/el/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/04_%C9%9B_turkish_el.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Well done—that’s /ɛ/!",
+        "incorrect": "Nope—that wasn’t /ɛ/."
+      }
+    },
+    {
+      "id": 5,
+      "target": "/æ/",
+      "samples": [
+        { "text": "cat", "IPA": "/kæt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/13_%C3%A6_ref_cat.mp3"},
+        { "text": "bat", "IPA": "/bæt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/14_%C3%A6_ref_bat.mp3"},
+        { "text": "ham", "IPA": "/hæm/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/15_%C3%A6_ref_ham.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Afrikaans",   "word": "perd",     "IPA":"/pæːrt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/05_%C3%A6_afrikaans_perd.mp3" },
+          { "language": "Finnish", "word": "hän","IPA":"/hæn/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/05_%C3%A6_finnish_ha%CC%88n.mp3" },
+          { "language": "Norwegian", "word": "vært",     "IPA":"/vært/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/05_%C3%A6_norwegian_v%C3%A6rt.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Spanish",  "word": "pan",      "IPA":"/pan/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/05_%C3%A6_spanish_pan.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Right—that’s /æ/!",
+        "incorrect": "Oops—that wasn’t /æ/."
+      }
+    },
+    {
+      "id": 6,
+      "target": "/ɑː/",
+      "samples": [
+        { "text": "spa", "IPA":"/spɑː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/22_%C9%91_ref_spa.mp3"},
+        { "text": "bra", "IPA":"/brɑː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/23_%C9%91_ref_bra.mp3"},
+        { "text": "car", "IPA":"/kɑː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/24_%C9%91_ref_car.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "French",   "word": "arm",     "IPA":"/ɑʁm/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/06_%C9%91_french_arm.mp3" },
+          { "language": "Hindi", "word": "बात","IPA":"/bɑːt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/06_%C9%91_hindi_%E0%A4%AC%E0%A4%BE%E0%A4%A4.mp3" },
+          { "language": "Turkish", "word": "arkadaş",     "IPA":"/aɾka.daʃ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/06_%C9%91_turkish_arkadas%CC%A7.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Korean",  "word": "바다","IPA":"/pa.da/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/06_%C9%91_korean_%E1%84%87%E1%85%A1%E1%84%83%E1%85%A1.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "You got the /ɑː/!",
+        "incorrect": "That was not /ɑː/."
+      }
+    },
+    {
+      "id": 7,
+      "target": "/ɔː/",
+      "samples": [
+        { "text": "saw", "IPA":"/sɔː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/25_%C9%94_ref_saw.mp3"},
+        { "text": "law", "IPA":"/lɔː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/26_%C9%94_ref_law.mp3"},
+        { "text": "paw", "IPA":"/pɔː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/27_%C9%94_ref_paw.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "French", "word": "or",      "IPA":"/ɔʁ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/07_%C9%94_french_or.mp3" },
+          { "language": "German", "word": "Gott",     "IPA":"/okuɫ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/07_%C9%94_german_Gott.mp3" },
+          { "language": "Portuguese",   "word": "porta",     "IPA":"/ˈpɔɾtɐ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/07_%C9%94_portuguese_porta.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Hindi",   "word": "आउट",     "IPA":"/aʊt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/07_%C9%94_hindi_%E0%A4%86%E0%A4%89%E0%A4%9F.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "That’s the /ɔː/ sound!",
+        "incorrect": "No—that wasn’t /ɔː/."
+      }
+    },
+    {
+      "id": 8,
+      "target": "/o/",
+      "samples": [
+        { "text": "go",   "IPA":"/ɡoʊ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/28_o_ref_go.mp3"},
+        { "text": "boat", "IPA":"/boʊt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/29_o_ref_boat.mp3"},
+        { "text": "show", "IPA":"/ʃoʊ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/30_o_ref_show.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Hindi",   "word": "को", "IPA":"/koː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/08_o_hindi_%E0%A4%95%E0%A5%8B.mp3" },
+          { "language": "Korean",  "word": "오리",   "IPA":"/o.ri/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/08_o_korean_%E1%84%8B%E1%85%A9%E1%84%85%E1%85%B5.mp3" },
+          { "language": "Spanish", "word": "sol",  "IPA":"/sol/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/08_o_spanish_sol.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "Turkish", "word": "su",   "IPA":"/su/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/08_o_turkish_su.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "That’s a perfect /o/!",
+        "incorrect": "Oops—that wasn’t /o/."
+      }
+    },
+    {
+      "id": 9,
+      "target": "/uː/",
+      "samples": [
+        { "text": "boot", "IPA":"/buːt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/34_u_ref_boot.mp3"},
+        { "text": "food", "IPA":"/fuːd/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/35_u_ref_food.mp3"},
+        { "text": "two",  "IPA":"/tuː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/36_u_ref_two.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language": "Hindi",   "word": "दूध", "IPA":"/d̪uːd̪ʱ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/09_u_hindi_+%E0%A4%A6%E0%A5%82%E0%A4%A7.mp3" },
+          { "language": "Turkish", "word": "bu",  "IPA":"/bu/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/09_u_turkish_bu.mp3" },
+          { "language": "Spanish", "word": "lus",  "IPA":"/lus/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/09_u_spanish_luz.mp3" }
+        ],
+        "wrong_answers": [
+          { "language": "French",  "word": "lune",   "IPA":"/lyn/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/09_u_french_lune.mp3" }
+        ]
+      },
+      "feedback": {
+        "correct": "Yes—that’s /uː/!",
+        "incorrect": "That one wasn’t /uː/."
+      }
+    },
+    {
+      "id": 10,
+      "target": "/ʊ/",
+      "samples": [
+        { "text":"foot","IPA":"/fʊt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/31_%CA%8A_ref_foot.mp3"},
+        { "text":"book","IPA":"/bʊk/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/32_%CA%8A_ref_book.mp3"},
+        { "text":"could","IPA":"/kʊd/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/33_%CA%8A_ref_could.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers":[
+
+          { "language":"German","word":"Hund",   "IPA":"/hʊnt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/10_%CA%8A_german_Hund.mp3"},
+          { "language":"Hindi","word":"कुत्ता","IPA":"/kʊत̪aː/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/10_%CA%8A_hindi_%E0%A4%95%E0%A5%81%E0%A4%A4%E0%A5%8D%E0%A4%A4%E0%A4%BE.mp3"},
+          { "language":"Russian","word":"гусь","IPA":"/ɡʊsʲ/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/10_%CA%8A_russian_%D0%B3%D1%83%D1%81%D1%8C.mp3"}
+        ],
+        "wrong_answers":[
+          { "language":"Afrikaans","word":"suiker","IPA":"/ˈsœy.kər/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/quiz/10_%CA%8A_afrikaans_suiker.mp3"}
+        ]
+      },
+      "feedback": {
+        "correct":"That’s the foot vowel (/ʊ/)!",
+        "incorrect":"No—that wasn’t /ʊ/."
+      }
+    },
+    {
+      "id": 11,
+      "target": "/ʌ/",
+      "samples": [
+        { "text":"strut","IPA":"/strʌt/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/19_%CA%8C_ref_strut.mp3"},
+        { "text":"mud",  "IPA":"/mʌd/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/20_%CA%8C_ref_mud.mp3"},
+        { "text":"cup",  "IPA":"/kʌp/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/21_%CA%8C_ref_cup.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers":[
+          { "language":"Hindi","word":"उत्पत्ति","IPA":"/ʊtpətt̪i/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/उत्पत्ति.mp3"},
+          { "language":"Turkish","word":"kulüp","IPA":"/ku.lœp/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/kulüp.mp3"},
+          { "language":"French","word":"un",   "IPA":"/œ̃/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/un.mp3"}
+        ],
+        "wrong_answers":[
+          { "language":"Korean","word":"버","IPA":"/pʌ/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/버.mp3"}
+        ]
+      },
+      "feedback": {
+        "correct":"Perfect—the /ʌ/ sound!",
+        "incorrect":"Not that one—/ʌ/ is the “uh” in “strut.”"
+      }
+    },
+    {
+      "id": 12,
+      "target": "/ə/",
+      "samples": [
+        { "text": "the",   "IPA":"/ðə/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/16_%C9%99_ref_the.mp3"},
+        { "text": "to",    "IPA":"/tə/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/17_%C9%99_ref_to.mp3"},
+        { "text": "alone","IPA":"/əˈloʊn/","audio":"https://phonetics-media.s3.us-east-1.amazonaws.com/audio/words/18_%C9%99_ref_alone.mp3"}
+      ],
+      "options_pool": {
+        "correct_answers": [
+          { "language":"Hindi","word":"कमल","IPA":"/kə.məl/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/कमल.mp3"},
+          { "language":"Turkish","word":"kupa","IPA":"/ku.pa/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/kupa.mp3"},
+          { "language":"French","word":"le",   "IPA":"/lə/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/le.mp3"}
+        ],
+        "wrong_answers": [
+          { "language":"Korean","word":"그","IPA":"/kɯ/","audio":"https://s3.amazonaws.com/your-bucket/audio_samples/그.mp3"}
+        ]
+      },
+      "feedback": {
+        "correct": "Spot on—that’s the schwa (/ə/)!",
+        "incorrect": "No—the schwa (/ə/) is that “uh” sound."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds initial quiz content for **Phonic Trio**, structured by id and target phoneme. Each entry includes a samples array of reference words and an options_pool with randomized correct_answers and wrong_answers to support dynamic quiz generation.

- 	Currently scoped to a single iteration per phoneme
- 	Future updates will support rotating samples and generating quizzes dynamically per vowel
- 	Feedback strings are placeholders and will be expanded in later versions